### PR TITLE
fix: prevent body overflow hidden when dropdown opens

### DIFF
--- a/frontend/src/components/molecules/UserProfileButton.tsx
+++ b/frontend/src/components/molecules/UserProfileButton.tsx
@@ -94,6 +94,7 @@ export default function UserProfileButton({
           anchorEl={anchorEl}
           open={open}
           onClose={handleClose}
+          disableScrollLock
           MenuListProps={{
             "aria-labelledby": "basic-button",
           }}


### PR DESCRIPTION
## List of changes

- Add / Fix / Change / Remove

## Checklist

- [related issue](https://github.com/IntersectMBO/cc-portal/issues/)
- [ ] My changes generate no new warnings
- [ ] My code follows the [style guidelines](https://github.com/IntersectMBO/cc-portal/tree/main/docs/style-guides) of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
